### PR TITLE
Fixing inside Docker container check

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -9,6 +9,7 @@ correct() { [ "$(cut -d' ' -f 2 <"$BENCHMARK.hash" | grep -vc 0)" -eq 0 ]; }
 
 in_container() {
   [ -f /proc/1/cgroup ] && grep -qaE 'docker|kubepods|containerd' /proc/1/cgroup && return 0
+  [ -f /proc/1/cgroup ] && grep -w '0::/' /proc/1/cgroup && return 0
   [ -f /.dockerenv ] && return 0
   return 1
 }


### PR DESCRIPTION
It seems that the cgroup file sometimes only has `0::/` instead of docker or containerd service in it.